### PR TITLE
refactor - move exportation line to last line

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import CompilerTester from "./components/CompilerTester";
 
 import "@/App.css";
 
-export default function App() {
+function App() {
   return (
     <AppContainer>
       <CompilerTester />
@@ -22,3 +22,5 @@ const AppContainer = styled("div")`
 
   background: #2a3383;
 `;
+
+export default App;

--- a/src/components/CompilerTester.tsx
+++ b/src/components/CompilerTester.tsx
@@ -6,7 +6,7 @@ import DynamicComponent from "@/components/DynamicComponent";
 import StateChanger from "@/components/StateChanger";
 import StaticComponent from "@/components/StaticComponent";
 
-export default function CompilerTester() {
+function CompilerTester() {
   const [value, setValue] = useState("");
 
   const handleTextStateChange = (changedValue: string) => {
@@ -38,3 +38,5 @@ const CompilerTesterContainer = styled("div")`
     20px 20px 50px #151940,
     -20px -20px 50px #3f4dc6;
 `;
+
+export default CompilerTester;

--- a/src/components/DynamicComponent.tsx
+++ b/src/components/DynamicComponent.tsx
@@ -6,9 +6,7 @@ interface DynamicComponentProps {
   dynamicValue: string;
 }
 
-export default function DynamicComponent({
-  dynamicValue,
-}: DynamicComponentProps) {
+function DynamicComponent({ dynamicValue }: DynamicComponentProps) {
   const splittedValues = dynamicValue.split("");
 
   return (
@@ -29,3 +27,5 @@ const DynamicComponentContainer = styled("div")`
   flex-wrap: wrap;
   overflow: scroll;
 `;
+
+export default DynamicComponent;

--- a/src/components/DynamicStateHolder.tsx
+++ b/src/components/DynamicStateHolder.tsx
@@ -4,7 +4,7 @@ interface DynamicStateHolderProps {
   value: string;
 }
 
-export default function DynamicStateHolder({ value }: DynamicStateHolderProps) {
+function DynamicStateHolder({ value }: DynamicStateHolderProps) {
   const isEmpty = value.trim() === "";
 
   return (
@@ -27,3 +27,5 @@ const DynamicStateHolderContainer = styled(
   border: $showBorder ? "1px solid white" : "none",
   borderRadius: "0.5rem",
 }));
+
+export default DynamicStateHolder;

--- a/src/components/StateChanger.tsx
+++ b/src/components/StateChanger.tsx
@@ -4,7 +4,7 @@ interface StateChangerProps {
   onChange: (value: string) => void;
 }
 
-export default function StateChanger({ onChange }: StateChangerProps) {
+function StateChanger({ onChange }: StateChangerProps) {
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const value = event.target.value;
     onChange(value);
@@ -40,3 +40,5 @@ const StyledTextField = styled("input")`
     border-color: black;
   }
 `;
+
+export default StateChanger;

--- a/src/components/StaticComponent.tsx
+++ b/src/components/StaticComponent.tsx
@@ -1,6 +1,6 @@
 import { styled } from "@mui/material";
 
-export default function StaticComponent() {
+function StaticComponent() {
   return (
     <StaticComponentContainer>React Compiler Test</StaticComponentContainer>
   );
@@ -10,3 +10,5 @@ const StaticComponentContainer = styled("div")`
   color: white;
   font-weight: 900;
 `;
+
+export default StaticComponent;


### PR DESCRIPTION
# Pull Request

### Changes

#### refactor - move exportation line to last line
- Inline exportation could give hardness for memoization.
- Could recognize what is the default module exported easily